### PR TITLE
Improvment of renderer multimedias and better documentation

### DIFF
--- a/classes/renderer/multimedias.php
+++ b/classes/renderer/multimedias.php
@@ -8,13 +8,13 @@ class Renderer_MultiMedias extends Renderer
 {
     protected static $DEFAULT_RENDERER_OPTIONS = array(
         'limit' => false,
-        'mode' => 'all',
+        'mode'  => 'all',
     );
 
     public function build()
     {
         $attr_id = $this->get_attribute('id');
-        $id = !empty($attr_id) ? $attr_id : uniqid('multimedias_');
+        $id      = !empty($attr_id) ? $attr_id : uniqid('multimedias_');
         $this->fieldset()->append(static::js_init($id));
         $key = !empty($this->renderer_options['key']) ? $this->renderer_options['key'] : $this->name;
 
@@ -23,21 +23,21 @@ class Renderer_MultiMedias extends Renderer
             $this->set_value($this->getValueFromInstance($item, $key));
         }
 
-        return (string) \View::forge('novius_renderers::multimedias/inputs', array(
-            'id' => $id,
-            'key' => $key,
+        return (string)\View::forge('novius_renderers::multimedias/inputs', array(
+            'id'      => $id,
+            'key'     => $key,
             'options' => $this->renderer_options,
-            'item' => $item,
-            'value' => $this->value,
+            'item'    => $item,
+            'value'   => $this->value,
         ), false);
     }
 
     protected function getValueFromInstance($item, $key)
     {
         $value = array();
-        $index=1;
-        while(!empty($item->medias->{$key.$index})) {
-            $media = $item->medias->{$key.$index};
+        $index = 1;
+        while (!empty($item->medias->{$key . $index})) {
+            $media = $item->medias->{$key . $index};
             if (!empty($media)) {
                 $value[$index] = $media->id;
                 $index++;

--- a/classes/renderer/multimedias.php
+++ b/classes/renderer/multimedias.php
@@ -17,12 +17,32 @@ class Renderer_MultiMedias extends Renderer
         $id = !empty($attr_id) ? $attr_id : uniqid('multimedias_');
         $this->fieldset()->append(static::js_init($id));
         $key = !empty($this->renderer_options['key']) ? $this->renderer_options['key'] : $this->name;
+
+        $item = $this->fieldset()->getInstance();
+        if (!empty($item)) {
+            $this->set_value($this->getValueFromInstance($item, $key));
+        }
+
         return (string) \View::forge('novius_renderers::multimedias/inputs', array(
             'id' => $id,
             'key' => $key,
-            'item' => $this->fieldset()->getInstance(),
-            'options' => $this->renderer_options
+            'options' => $this->renderer_options,
+            'value' => $this->value,
         ), false);
+    }
+
+    protected function getValueFromInstance($item, $key)
+    {
+        $value = array();
+        $index=1;
+        while(!empty($item->medias->{$key.$index})) {
+            $media = $item->medias->{$key.$index};
+            if (!empty($media)) {
+                $value[$index] = $media->id;
+                $index++;
+            }
+        }
+        return $value;
     }
 
     public static function js_init($id)

--- a/classes/renderer/multimedias.php
+++ b/classes/renderer/multimedias.php
@@ -27,6 +27,7 @@ class Renderer_MultiMedias extends Renderer
             'id' => $id,
             'key' => $key,
             'options' => $this->renderer_options,
+            'item' => $item,
             'value' => $this->value,
         ), false);
     }

--- a/novius_docs/multimedias/config.sample
+++ b/novius_docs/multimedias/config.sample
@@ -29,7 +29,7 @@
 
         //flush database
         if(!$item->is_new()) {
-            $query = \DB::delete('nos_media_link')->where('medil_from_table', '=', Model::table())
+            $query = \DB::delete('nos_media_link')->where('medil_from_table', '=', $item->table())
                 ->where_open()
                 ->where('medil_foreign_id', '=', $item->id)
                 ->where('medil_key', 'LIKE', 'image%');
@@ -38,7 +38,10 @@
                 $query->where('medil_key', 'NOT IN', $keys);
             }
             $query->where_close()
-                ->or_where('medil_foreign_id', 'IS', \DB::expr('NULL'))
+                ->or_where_open()
+                    ->where('medil_foreign_id', 'IS', \DB::expr('NULL'))
+                    ->where('medil_foreign_context_common_id', 'IS', \DB::expr('NULL'))
+                ->or_where_close()
                 ->or_where('medil_media_id', '=', 0)
                 ->execute();
         }

--- a/views/multimedias/inputs.view.php
+++ b/views/multimedias/inputs.view.php
@@ -3,16 +3,17 @@
 $index = 1;
 $value = (array) $value;
 foreach ($value as $media_id) {
-    if (empty($media_id)) continue;
-    echo \Nos\Media\Renderer_Media::renderer(
-        array(
-            'name' => $key.'['.$index.']',
-            'value' => $media_id,
-            'required' => false,
-            'renderer_options' => $options,
-        )
-    );
-    $index++;
+    if (!empty($media_id)) {
+        echo \Nos\Media\Renderer_Media::renderer(
+            array(
+                'name' => $key.'['.$index.']',
+                'value' => $media_id,
+                'required' => false,
+                'renderer_options' => $options,
+            )
+        );
+        $index++;
+    }
 }
 //if limit = 0 OR false, or if number of medias < limit, an additional media can be add
 if ((!$options['limit']) || $index <= $options['limit']) {

--- a/views/multimedias/inputs.view.php
+++ b/views/multimedias/inputs.view.php
@@ -1,12 +1,13 @@
 <div id="<?= $id ?>">
 <?php
 $index = 1;
-while(!empty($item->medias->{$key.$index})) {
-    $media = $item->medias->{$key.$index};
+$value = (array) $value;
+foreach ($value as $media_id) {
+    if (empty($media_id)) continue;
     echo \Nos\Media\Renderer_Media::renderer(
         array(
             'name' => $key.'['.$index.']',
-            'value' => isset($media->media_id) && !empty($media->media_id) ? $media->media_id : null,
+            'value' => $media_id,
             'required' => false,
             'renderer_options' => $options,
         )


### PR DESCRIPTION
The documentation was old and do not take in count shared medias when the database is flush.

The renderer now use his value to populate himself.

This allow the use of this renderer without a model.
