### PR TITLE
Custom search on model

### DIFF
--- a/classes/controller/admin/autocomplete.php
+++ b/classes/controller/admin/autocomplete.php
@@ -19,6 +19,8 @@ class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
             $model = \Input::post('model', '');
             $from_id = intval(\Input::post('from_id', ''));
             $insert_option = \Input::post('insert_option', false);
+            $searchField = \Input::post('fields');
+            $display = \Input::post('display');
 
             if (!empty($model)) {
 
@@ -34,23 +36,42 @@ class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
                 // Create the base query from the model
                 $query = $model::query()->get_query();
 
-                // Select only the primary key and the title
-                $query = $query->select_array(array(
+                $fieldArray = array(
                     array($pk_property, 'value'),
                     array($title_property, 'label')
-                ), true);
+                );
+
+                if (!empty($display)) {
+                    $keys = array_keys($display);
+                    foreach ($keys as $key) {
+                        $fieldArray[] = array($key, $key);
+                    }
+                }
+
+
+                if (empty($searchField)) {
+                    $searchField = array($title_property);
+                }
+
+                // Select only the primary key and the title
+                $query = $query->select_array($fieldArray, true);
 
                 // Do not search on the item where the autocomplete appears
                 $query->where($pk_property, '!=', $from_id);
 
                 // Apply filter on query
                 if (!empty($filter)) {
-                    $query->where_open()
-                        ->or_where($title_property, 'LIKE', '%' . $filter . '%')
-                        ->where_close();
+
+                    $query->where_open();
+                    foreach ($searchField as $field) {
+                        $query->or_where($field, 'LIKE', '%' . $filter . '%');
+                    }
+
+
+                    $query->where_close();
                 }
 
-                // Limit (optionnal)
+            // Limit (optionnal)
                 \Config::load('novius_renderers::renderer/autocomplete', true);
                 $max_suggestions = \Config::get('novius_renderers::renderer/autocomplete.max_suggestions', array());
                 if (!empty($max_suggestions)) {
@@ -63,6 +84,22 @@ class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
                     ->execute()
                     ->as_array()
                 );
+
+                if (!empty($results) && !empty($display)) {
+                    foreach ($results as $resultKey => $result) {
+                        $label = '';
+                        foreach ($display as $key => $template) {
+
+                            if (!empty($result[$key])) {
+                                $label .= ' ' . strtr($template, array('{{field}}' => $result[$key]));
+                            }
+                        }
+                        if (!empty($label)) {
+                            $results[$resultKey]['label'] = $label;
+                        }
+                    }
+                }
+
                 if ($insert_option) {
                     array_unshift($results, array(
                         'value' => 0,

--- a/classes/controller/admin/autocomplete.php
+++ b/classes/controller/admin/autocomplete.php
@@ -2,6 +2,7 @@
 
 namespace Novius\Renderers;
 
+use Fuel\Core\Crypt;
 use Fuel\Core\Input;
 
 class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
@@ -14,6 +15,13 @@ class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
 
     public function action_search_model() {
         try {
+            // Uncrypt sensitive data and merge them to the post values
+            $cryptedPosts = \Input::post('crypted_post');
+            if (!empty($cryptedPosts)) {
+                $crypt = new Crypt();
+                $cryptedPosts = json_decode($crypt->decode($cryptedPosts), true);
+                $_POST = \Arr::merge_assoc($_POST, $cryptedPosts);
+            }
             $results = array();
             $filter = trim(\Input::post('search', ''));
             $model = \Input::post('model', '');

--- a/classes/renderer/autocomplete.php
+++ b/classes/renderer/autocomplete.php
@@ -148,12 +148,11 @@ class Renderer_Autocomplete extends \Fieldset_Field
         $item = $this->fieldset()->getInstance();
 
         if (!empty($item)) {
-            $crypt = new Crypt();
             // Add the current item ID to the posted vars (used to prevent current item to appear in suggestions)
-            $this->set_attribute('data-autocomplete-post', $crypt->encode(static::json_merge(
-                $crypt->decode($this->get_attribute('data-autocomplete-post')),
+            $this->set_attribute('data-autocomplete-post', static::json_merge(
+                $this->get_attribute('data-autocomplete-post'),
                 array('from_id' => $item->implode_pk($item))
-            )));
+            ));
         }
 
         // Keeps the renderer working if populate was made thanks to a key in renderer_options (backward compatibility)

--- a/classes/renderer/autocomplete.php
+++ b/classes/renderer/autocomplete.php
@@ -10,6 +10,7 @@
 
 namespace Novius\Renderers;
 
+use Fuel\Core\Crypt;
 use Fuel\Core\Fieldset;
 use Nos\Config_Common;
 use Orm\Model;
@@ -124,6 +125,9 @@ class Renderer_Autocomplete extends \Fieldset_Field
         // Prevent from displaying native autocomplete
         $attributes['autocomplete'] = 'off';
 
+        // Crypt post data
+        $crypt                                = new Crypt();
+        $attributes['data-autocomplete-post'] = json_encode(array('crypted_post' => $crypt->encode($attributes['data-autocomplete-post'])));
         return array($attributes, $options);
     }
 
@@ -144,11 +148,12 @@ class Renderer_Autocomplete extends \Fieldset_Field
         $item = $this->fieldset()->getInstance();
 
         if (!empty($item)) {
+            $crypt = new Crypt();
             // Add the current item ID to the posted vars (used to prevent current item to appear in suggestions)
-            $this->set_attribute('data-autocomplete-post', static::json_merge(
-                $this->get_attribute('data-autocomplete-post'),
+            $this->set_attribute('data-autocomplete-post', $crypt->encode(static::json_merge(
+                $crypt->decode($this->get_attribute('data-autocomplete-post')),
                 array('from_id' => $item->implode_pk($item))
-            ));
+            )));
         }
 
         // Keeps the renderer working if populate was made thanks to a key in renderer_options (backward compatibility)

--- a/novius_docs/autocomplete/readme.txt
+++ b/novius_docs/autocomplete/readme.txt
@@ -15,6 +15,8 @@ The use of the Renderer is therefore related to how it is included in the crud c
         - 'data-autocomplete-minlength' : optional
             Numbers of chars needed to perform the search.
             Default value : 3
+        - 'data-autocomplete-post' : optional
+            Serialized post data to give to the autocomplete request
         - 'data-name' : optional
             Choose a name for the hidden input (and not the one used for the input itself)
             "name" of the field + "-id". eg "field_name-id"
@@ -29,6 +31,19 @@ The use of the Renderer is therefore related to how it is included in the crud c
 - 'renderer_options' -> 'insert_option' : optional
         Add the ability to create content on click when there's no result.
 
+===== Model Configuration =====
+
+You can use a model to search directly.
+
+You need to pass the key 'model' to the data-autocomplete-post to search in it.
+
+You can also specify how to display / search this model with the properties display and fields respectively.
+
+fields is an array of table fields to search.
+
+display is an associative array [field_name] => 'display information'.
+
+The tag {{field}} will be replaced by the field value in the information. Is the value is not found or is empty, the field won't be displayed.
 
 ===== Update options afterward ====
 
@@ -78,3 +93,27 @@ $input.trigger(event);
         'field_name' => array() //needed for single select. the key must be the real name of your property. Don't need this if the 'multiple' option is set to 1
     )
     ...
+
+
+====== Custom search on a model ====
+
+<?=
+    Novius\Renderers\Renderer_Autocomplete::renderer(array(
+        'name' => 'field_name',
+        'class' => 'class_for_input_field',
+        'renderer_options' => array(
+            'data' => array(
+                'data-autocomplete-url' => 'admin/application/folder/crud/autocomplete',
+                'data-autocomplete-post' => \Format::forge(array(
+                    'model'   => 'Cinematheque\Films\Model_Film', // Search a film
+                    'fields'  => array('film_titre', 'film_titre_vo'), // Search on those two fields
+                    'display' => array(
+                        'film_titre'          => '{{field}}', // Display field
+                        'film_titre_vo'       => '({{field}})', // Display field between parenthesis
+                        'film_realisateur_id' => '{{field}}'
+                    )
+                )
+            )
+        ),
+    ));
+?>


### PR DESCRIPTION
I added the possibility to make custom search on a model with the autocomplete renderer.

You can specify the data 'fields' and 'display'.

field is an array of fields on which the query will be made with OR.
display is an associative array of fields you want to display.

The config is then something like this (i have updated the docs for this usage)

``` php
Novius\Renderers\Renderer_Autocomplete::renderer(array(
        'name' => 'field_name',
        'class' => 'class_for_input_field',
        'renderer_options' => array(
            'data' => array(
                'data-autocomplete-url' => 'admin/application/folder/crud/autocomplete',
                'data-autocomplete-post' => \Format::forge(array(
                    'model'   => 'Cinematheque\Films\Model_Film', // Search a film
                   'fields'  => array('film_titre', 'film_titre_vo'), // Search on those two fields  
                   'display' => array(
                        'film_titre'          => '{{field}}', // Display field
                       'film_titre_vo'       => '({{field}})', // Display field between parenthesis
                        'film_realisateur_id' => '{{field}}'
                    )
               )
            )
       ),
+    ));
```
