### PR TITLE
Renderer crudlink

### DIFF
--- a/classes/renderer/crudlink.php
+++ b/classes/renderer/crudlink.php
@@ -16,7 +16,6 @@ use Nos\Renderer_Text;
 class Renderer_CrudLink extends Renderer_Text
 {
     protected $renderer_options = array();
-
     protected static $_cacheCrud = array();
 
     protected function defaultOptions()
@@ -28,7 +27,6 @@ class Renderer_CrudLink extends Renderer_Text
 
     public function __construct($name, $label = '', array $attributes = array(), array $rules = array(), \Fuel\Core\Fieldset $fieldset)
     {
-
         $this->renderer_options = \Arr::merge($this->defaultOptions(), \Arr::get($attributes, 'renderer_options', array()));
         parent::__construct($name, $label, $attributes, $rules, $fieldset);
     }
@@ -59,7 +57,7 @@ class Renderer_CrudLink extends Renderer_Text
         return (string)parent::build();
     }
 
-    private function findCrud($class, $app)
+    protected function findCrud($class, $app)
     {
         if (!\Arr::get(static::$_cacheCrud, $class)) {
             $configDir      = APPPATH . "applications/$app/config/";
@@ -73,7 +71,7 @@ class Renderer_CrudLink extends Renderer_Text
         return static::$_cacheCrud[$class];
     }
 
-    private function searchDir($dir, $class, $app, $currentDirectory)
+    protected function searchDir($dir, $class, $app, $currentDirectory)
     {
         $dir = (array)$dir;
         foreach ($dir as $dirname => $file) {
@@ -99,7 +97,7 @@ class Renderer_CrudLink extends Renderer_Text
 
     }
 
-    private function cleanFilename($file)
+    protected function cleanFilename($file)
     {
         $infos     = pathinfo($file);
         $filename  = $infos['filename'];

--- a/classes/renderer/crudlink.php
+++ b/classes/renderer/crudlink.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * NOVIUS OS - Web OS for digital communication
+ *
+ * @copyright  2013 Novius
+ * @license    GNU Affero General Public License v3 or (at your option) any later version
+ *             http://www.gnu.org/licenses/agpl-3.0.html
+ * @link       http://www.novius-os.org
+ */
+
+namespace Novius\Renderers;
+
+use Fuel\Core\Inflector;
+use Nos\Renderer_Text;
+
+class Renderer_CrudLink extends Renderer_Text
+{
+    protected $renderer_options = array();
+
+    protected static $_cacheCrud = array();
+
+    protected function defaultOptions()
+    {
+        \Nos\I18n::current_dictionary('novius_renderers::default');
+        return array('text' => __('See the {{MODEL}}\'s page', 'url' => ''));
+    }
+
+
+    public function __construct($name, $label = '', array $attributes = array(), array $rules = array(), \Fuel\Core\Fieldset $fieldset)
+    {
+
+        $this->renderer_options = \Arr::merge($this->defaultOptions(), \Arr::get($attributes, 'renderer_options', array()));
+        parent::__construct($name, $label, $attributes, $rules, $fieldset);
+    }
+
+    /**
+     * How to display the field
+     *
+     * @return string
+     */
+    public function build()
+    {
+
+        $item = $this->value;
+        $text = \Arr::get($this->renderer_options, 'text', '');
+        $url  = \Arr::get($this->renderer_options, 'url', '');
+
+        if (is_subclass_of($item, '\Nos\Orm\Model')) {
+            $app   = $item->getApplication();
+            $class = get_class($item);
+            $crud  = $this->findCrud($class, $app);
+            if ($crud) {
+                $url = $crud . '/insert_update/' . $this->value->id;
+            }
+            $text = strtr($text, array('{{MODEL}}' => Inflector::humanize(Inflector::singularize((Inflector::tableize($class))))));
+
+        }
+        $this->value = \View::forge('novius_renderers::crudlink/link', compact('text', 'url'))->render();
+        return (string)parent::build();
+    }
+
+    private function findCrud($class, $app)
+    {
+        if (!\Arr::get(static::$_cacheCrud, $class)) {
+            $configDir      = APPPATH . "applications/$app/config/";
+            $controllerPath = 'controller/admin/';
+            $listConfig     = \File::read_dir($configDir . $controllerPath);
+            $found          = $this->searchDir($listConfig, $class, $app, $controllerPath);
+            if (!empty($found)) {
+                static::$_cacheCrud[$class] = \Arr::get($found, 'controller_url');
+            }
+        }
+        return static::$_cacheCrud[$class];
+    }
+
+    private function searchDir($dir, $class, $app, $currentDirectory)
+    {
+        $dir = (array)$dir;
+        foreach ($dir as $dirname => $file) {
+            if (is_array($file)) {
+                foreach ($dir as $file) {
+                    $return = $this->searchDir($file, $class, $app, $currentDirectory . $dirname);
+                    if (!empty($return)) {
+                        return $return;
+                    }
+                }
+                continue;
+            }
+            $filename = $this->cleanFilename($file);
+            $config   = \Config::load("$app::{$currentDirectory}{$filename}", true);
+            if (empty($config)) {
+                continue;
+            }
+            if (\Arr::get($config, 'model') === $class && \Arr::get($config, 'controller_url', null)) {
+                return $config;
+            }
+        }
+        return false;
+
+    }
+
+    private function cleanFilename($file)
+    {
+        $infos     = pathinfo($file);
+        $filename  = $infos['filename'];
+        $suffixPos = strpos($filename, '.config');
+        if ($suffixPos !== false) {
+            $filename = substr($filename, 0, $suffixPos);
+        }
+        return $filename;
+    }
+}

--- a/classes/renderer/crudlink.php
+++ b/classes/renderer/crudlink.php
@@ -22,7 +22,7 @@ class Renderer_CrudLink extends Renderer_Text
     protected function defaultOptions()
     {
         \Nos\I18n::current_dictionary('novius_renderers::default');
-        return array('text' => __('See the {{MODEL}}\'s page', 'url' => ''));
+        return array('text' => __('See the {{MODEL}}\'s page'), 'url' => '');
     }
 
 

--- a/lang/fr/default.lang.php
+++ b/lang/fr/default.lang.php
@@ -38,4 +38,7 @@ return array(
     #: config/renderer/modelsearch.config.php:6
     'Page' => 'Page',
 
+    #: classes/controller/admin/crudlink.php
+    'See the {{MODEL}}\'s page' => 'Voir la fiche {{MODEL}}'
+
 );

--- a/novius_docs/crudlink/readme.txt
+++ b/novius_docs/crudlink/readme.txt
@@ -1,0 +1,29 @@
+=== Introduction ===
+
+This renderer gives the ability to display a link to a model's crud.
+
+=== Configuration ===
+
+You need to populate the field with an instance of Nos\Orm\Model. The link to the correct crud will be displayed if the crud exists.
+
+==== renderer_options ====
+
+text : default ('See the {{MODEL}}\'s page')
+
+The text displayed inside the link.
+
+=== Example ===
+
+```php
+'link'                       => array(
+    'label'            => __('Crud Link'),
+    'renderer'         => '\Novius\Renderers\Renderer_CrudLink',
+    'renderer_options' => array(),
+    'populate'         => function ($item) {
+                return $item->related_item;
+        },
+    'show_when'        => function ($item) {
+            return (!empty($item->related_item);
+        }
+),
+```

--- a/views/crudlink/link.view.php
+++ b/views/crudlink/link.view.php
@@ -35,7 +35,6 @@ $id = uniqid();
                         url: url
                     }
                 });
-                console.log('bite');
                 return false;
             });
         });

--- a/views/crudlink/link.view.php
+++ b/views/crudlink/link.view.php
@@ -1,0 +1,43 @@
+<?php
+$id = uniqid();
+?>
+
+<div id="<?= $id ?>">
+    <?php
+    if ($url) {
+    ?>
+    <a href="<?= $url ?>">
+        <?php
+        }
+
+        echo $text;
+        if ($url) {
+        ?>
+    </a>
+<?php
+}
+?>
+</div>
+
+<script>
+    require([
+        'jquery-nos'
+    ], function ($) {
+        $(function () {
+            var $input = $('#<?= $id ?>');
+            $input.find('a').click(function () {
+                $this = $(this);
+                url = $this.attr('href');
+                $(this).nosAction({
+                    action: 'nosTabs',
+                    method: 'add',
+                    tab   : {
+                        url: url
+                    }
+                });
+                console.log('bite');
+                return false;
+            });
+        });
+    });
+</script>


### PR DESCRIPTION
Added a renderer to display a link to a crud element (or any link to a new nos_tabs by extension).

The usage is fairly simple.

``` php
'link'                       => array(
    'renderer'         => '\Novius\Renderers\Renderer_CrudLink',
    'renderer_options' => array(),
    'populate'         => function ($item) {
                return $item->related_item;
        },
)
```

It will automatically detect the correct crud and create a link.
