### PR TITLE
Autocomplete - Check if item exists

### DIFF
--- a/classes/renderer/autocomplete.php
+++ b/classes/renderer/autocomplete.php
@@ -143,11 +143,13 @@ class Renderer_Autocomplete extends \Fieldset_Field
         // Get the current fieldset item
         $item = $this->fieldset()->getInstance();
 
-        // Add the current item ID to the posted vars (used to prevent current item to appear in suggestions)
-        $this->set_attribute('data-autocomplete-post', static::json_merge(
-            $this->get_attribute('data-autocomplete-post'),
-            array('from_id' => $item->implode_pk($item))
-        ));
+        if (!empty($item)) {
+            // Add the current item ID to the posted vars (used to prevent current item to appear in suggestions)
+            $this->set_attribute('data-autocomplete-post', static::json_merge(
+                $this->get_attribute('data-autocomplete-post'),
+                array('from_id' => $item->implode_pk($item))
+            ));
+        }
 
         // Keeps the renderer working if populate was made thanks to a key in renderer_options (backward compatibility)
         if (!empty($this->renderer_options['populate']) && is_callable($this->renderer_options['populate'])) {


### PR DESCRIPTION
When using this renderer with an empty item, it would crash attempting find the primary key.

With this fix i check if the item exists beforehand.
