### PR TITLE
Uncrypt data given by autocomplete

### DIFF
--- a/classes/controller/admin/modelsearch.php
+++ b/classes/controller/admin/modelsearch.php
@@ -2,6 +2,8 @@
 
 namespace Novius\Renderers;
 
+use Fuel\Core\Crypt;
+
 class Controller_Admin_ModelSearch extends \Nos\Controller_Admin_Application
 {
     public function prepare_i18n()
@@ -12,6 +14,13 @@ class Controller_Admin_ModelSearch extends \Nos\Controller_Admin_Application
 
     public function action_search() {
         try {
+            // Uncrypt sensitive data and merge them to the post values
+            $cryptedPosts = \Input::post('crypted_post');
+            if (!empty($cryptedPosts)) {
+                $crypt = new Crypt();
+                $cryptedPosts = json_decode($crypt->decode($cryptedPosts), true);
+                $_POST = \Arr::merge_assoc($_POST, $cryptedPosts);
+            }
             // Get the search keywords
             $keywords = trim(strval(\Input::post('search', '')));
 


### PR DESCRIPTION
The PR https://github.com/novius/novius_renderers/pull/12 added a crypt layer to the data sent by the renderer autocomplete.

The thing is, the renderer model search extend this class but couldn't understand the crypted data transmitted.

This is the bugfix.
