### PR TITLE
Bugfixes and improvements when using modelsearch in combination with hasmany

### DIFF
--- a/classes/controller/admin/autocomplete.php
+++ b/classes/controller/admin/autocomplete.php
@@ -3,7 +3,6 @@
 namespace Novius\Renderers;
 
 use Fuel\Core\Crypt;
-use Fuel\Core\Input;
 
 class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
 {
@@ -13,24 +12,49 @@ class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
         \Nos\I18n::current_dictionary('novius_renderers::default');
     }
 
-    public function action_search_model() {
-        try {
-            // Uncrypt sensitive data and merge them to the post values
-            $cryptedPosts = \Input::post('crypted_post');
-            if (!empty($cryptedPosts)) {
-                $crypt = new Crypt();
-                $cryptedPosts = json_decode($crypt->decode($cryptedPosts), true);
-                $_POST = \Arr::merge_assoc($_POST, $cryptedPosts);
-            }
-            $results = array();
-            $filter = trim(\Input::post('search', ''));
-            $model = \Input::post('model', '');
-            $from_id = intval(\Input::post('from_id', ''));
-            $insert_option = \Input::post('insert_option', false);
-            $searchField = \Input::post('fields');
-            $display = \Input::post('display');
+    public function before()
+    {
+        parent::before();
 
+        // Uncrypt the autocomplete configuration
+        $config = \Input::post('config');
+        if (!empty($config)) {
+            $crypt = new Crypt();
+            \Arr::set($_POST, 'config', unserialize($crypt->decode($config)));
+        }
+    }
+
+    public function action_search_model()
+    {
+        try {
+            $config = (array) \Input::post('config', array());
+
+            // The search string
+            $search_query = trim(\Input::post('search', ''));
+
+            // The model on which to search
+            $model = \Input::post('model', '');
+
+            // The ID of the item we are searching from
+            $from_id = intval(\Input::post('from_id', ''));
+
+            // The option to insert a new item
+            $insert_option = \Input::post('insert_option', false);
+
+            // The fields on which to search
+            $search_field = \Input::post('fields');
+
+            // The fields to display as the label in a result
+            $display_field = \Input::post('display');
+
+            $results = array();
             if (!empty($model)) {
+
+                // Check if the $model is available
+                $available_models = (array) \Arr::get($config, 'available_models', array());
+                if (!in_array($model, $available_models)) {
+                    throw new \Exception('This model is not compatible with this feature (not available).');
+                }
 
                 // Check if the current user has the permission to access the model
                 list($application) = \Config::configFile($model);
@@ -44,60 +68,53 @@ class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
                 // Create the base query from the model
                 $query = $model::query()->get_query();
 
-                $fieldArray = array(
+                // Adds the fields to display in the query select
+                $field_array = array(
                     array($pk_property, 'value'),
                     array($title_property, 'label')
                 );
-
-                if (!empty($display)) {
-                    $keys = array_keys($display);
+                if (!empty($display_field)) {
+                    $keys = array_keys($display_field);
                     foreach ($keys as $key) {
-                        $fieldArray[] = array($key, $key);
+                        $field_array[] = array($key, $key);
                     }
                 }
 
-
-                if (empty($searchField)) {
-                    $searchField = array($title_property);
-                }
-
                 // Select only the primary key and the title
-                $query = $query->select_array($fieldArray, true);
+                $query = $query->select_array($field_array, true);
 
                 // Do not search on the item where the autocomplete appears
                 $query->where($pk_property, '!=', $from_id);
 
-                // Apply filter on query
-                if (!empty($filter)) {
-
+                // Apply the search query
+                if (!empty($search_query)) {
                     $query->where_open();
-                    foreach ($searchField as $field) {
-                        $query->or_where($field, 'LIKE', '%' . $filter . '%');
+                    $search_field = !empty($search_field) ? (array) $search_field : array($title_property);
+                    foreach ($search_field as $field) {
+                        $query->or_where($field, 'LIKE', '%'.$search_query.'%');
                     }
-
-
                     $query->where_close();
                 }
 
-            // Limit (optionnal)
+                // Limit (optionnal)
                 \Config::load('novius_renderers::renderer/autocomplete', true);
                 $max_suggestions = \Config::get('novius_renderers::renderer/autocomplete.max_suggestions', array());
                 if (!empty($max_suggestions)) {
                     $query->limit($max_suggestions);
                 }
 
-                // Get query results
+                // Gets the query results
                 $results = array_filter((array) $query->order_by($title_property)
                     ->distinct(true)
                     ->execute()
                     ->as_array()
                 );
 
-                if (!empty($results) && !empty($display)) {
+                // Formats the results (eg. displayed fields)
+                if (!empty($results) && !empty($display_field)) {
                     foreach ($results as $resultKey => $result) {
                         $label = '';
-                        foreach ($display as $key => $template) {
-
+                        foreach ($display_field as $key => $template) {
                             if (!empty($result[$key])) {
                                 $label .= ' ' . strtr($template, array('{{field}}' => $result[$key]));
                             }
@@ -108,21 +125,23 @@ class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
                     }
                 }
 
+                // Adds an option in the results to insert a new item based on the search query
                 if ($insert_option) {
                     array_unshift($results, array(
                         'value' => 0,
                         'label' => __('Add one item')
                     ));
-                } else {
-                    if (empty($results)) {
-                        $results = array(
-                            array(
-                                'value' => 0,
-                                'label' => __('No content of that type has been found')
-                            )
-                        );
-                    }
                 }
+            }
+
+            // Sets a message if there are no results
+            if (empty($results)) {
+                $results = array(
+                    array(
+                        'value' => 0,
+                        'label' => __('No content of that type has been found')
+                    )
+                );
             }
 
             \Response::json($results);
@@ -149,7 +168,7 @@ class Controller_Admin_Autocomplete extends \Nos\Controller_Admin_Application
         //make config path
         $config_file = $app.'::controller/admin/'.implode('/', $segments);
 
-        if (Input::method() == 'GET') {
+        if (\Input::method() == 'GET') {
             if (!empty($crud) && !empty($js_id)) {
 
                 //Add a specific event on insert thanks to config

--- a/classes/controller/admin/hasmany.ctrl.php
+++ b/classes/controller/admin/hasmany.ctrl.php
@@ -10,19 +10,55 @@ class Controller_Admin_HasMany extends \Nos\Controller_Admin_Application
         $relation = \Input::get('relation');
         $order = \Input::get('order');
         $forge = \Input::get('forge', array());
+        $context = \Input::get('context');
+
+        // Duplicates an item
         if (!empty($forge)) {
             $base_item = $class::forge($forge);//if the forge contains an id, then it will not be considered as a new item
             $item = clone $base_item;
-        } else {
+        }
+        // Creates a new item
+        else {
             $item = $class::forge();
+            // Sets the context if provided
+            if (!empty($context)) {
+                $this->setItemContext($item, $context);
+            }
         }
 
-        $params = array(
-            'index' => $index,
-        );
-        $params['item'] = $item;
+        // Renders the fieldset
         $return = Renderer_HasMany::render_fieldset($item, $relation, $index, array('order' => (int) $order));
         \Response::forge($return)->send(true);
         exit();
+    }
+
+    /**
+     * Sets the $context on $item
+     *
+     * @param $item
+     * @param $context
+     * @return bool
+     */
+    public function setItemContext($item, $context)
+    {
+        // Gets the context properties from the behaviour
+        $context_properties = \Arr::get(array_values(array_filter($item::behaviours(array(
+            'Nos\Orm_Behaviour_Contextable',
+            'Nos\Orm_Behaviour_Twinnable'
+        )))), 0);
+        if (empty($context_properties)) {
+            return false;
+        }
+
+        // Gets the context property name
+        $context_property = \Arr::get($context_properties, 'context_property');
+        if (empty($context_property) || !isset($item->{$context_property})) {
+            return false;
+        }
+
+        // Sets the context
+        $item->{$context_property} = $context;
+
+        return true;
     }
 }

--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -28,6 +28,10 @@ class Renderer_HasMany extends \Nos\Renderer
 
         // Gets the fieldset item
         $item = $this->fieldset()->getInstance();
+        $context = $this->getItemContext($item);
+        if (!empty($this->renderer_options['context'])) {
+            $context = $this->renderer_options['context'];
+        }
 
         // Adds the javascript
         $this->fieldset()->append(static::js_init());
@@ -39,7 +43,7 @@ class Renderer_HasMany extends \Nos\Renderer
             'value' => $this->value,
             'model' => $this->renderer_options['model'],
             'item' => $item,
-            'context' => $this->getItemContext($item),
+            'context' => $context,
             'options' => $this->renderer_options,
             'data' => $data
         ), false)->render();
@@ -203,8 +207,10 @@ class Renderer_HasMany extends \Nos\Renderer
      * @return bool
      */
     public function getItemContext($item) {
-        if ($item::behaviours('Nos\Orm_Behaviour_Contextable') || $item::behaviours('Nos\Orm_Behaviour_Twinnable')) {
-            return $item->get_context();
+        if (!empty($item)) {
+            if ($item::behaviours('Nos\Orm_Behaviour_Contextable') || $item::behaviours('Nos\Orm_Behaviour_Twinnable')) {
+                return $item->get_context();
+            }
         }
         return false;
     }

--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -8,13 +8,16 @@ class Renderer_HasMany extends \Nos\Renderer
         'limit' => false,
     );
 
+    /**
+     * Builds the fieldset
+     *
+     * @return mixed|string
+     */
     public function build()
     {
-        $attr_id = $this->get_attribute('id');
-        $id = !empty($attr_id) ? $attr_id : uniqid('hasmany_');
         $key = !empty($this->renderer_options['name']) ? $this->renderer_options['name'] : $this->name;
         $relation = !empty($this->renderer_options['related']) ? $this->renderer_options['related'] : $this->name;
-        $this->fieldset()->append(static::js_init());
+
         $data = array();
         $attributes = $this->get_attribute();
         foreach ($attributes as $key => $value) {
@@ -22,13 +25,21 @@ class Renderer_HasMany extends \Nos\Renderer
                 $data[mb_substr($key, strlen('form-'))] = $value;
             }
         }
+
+        // Gets the fieldset item
+        $item = $this->fieldset()->getInstance();
+
+        // Adds the javascript
+        $this->fieldset()->append(static::js_init());
+
         $return = \View::forge('novius_renderers::hasmany/items', array(
-            'id' => $id,
+            'id' => $this->getId(),
             'key' => $key,
             'relation' => $relation,
             'value' => $this->value,
             'model' => $this->renderer_options['model'],
-            'item' => $this->fieldset()->getInstance(),
+            'item' => $item,
+            'context' => $this->getItemContext($item),
             'options' => $this->renderer_options,
             'data' => $data
         ), false)->render();
@@ -178,5 +189,23 @@ class Renderer_HasMany extends \Nos\Renderer
     public static function js_init()
     {
         return \View::forge('novius_renderers::hasmany/js', array(), false);
+    }
+
+    public function getId() {
+        $id = $this->get_attribute('id');
+        return !empty($id) ? $id : uniqid('hasmany_');
+    }
+
+    /**
+     * Returns the context of $item
+     *
+     * @param $item
+     * @return bool
+     */
+    public function getItemContext($item) {
+        if ($item::behaviours('Nos\Orm_Behaviour_Contextable') || $item::behaviours('Nos\Orm_Behaviour_Twinnable')) {
+            return $item->get_context();
+        }
+        return false;
     }
 }

--- a/novius_docs/hasmany/config_crud.sample
+++ b/novius_docs/hasmany/config_crud.sample
@@ -23,7 +23,12 @@ return array(
             'label' => __('Movie Show'),
             'renderer' => 'Novius\Renderers\Renderer_HasMany',
             'renderer_options' => array(
-                'model' => 'Model_MovieShow'
+                'model' => 'Model_MovieShow',
+                'related' => 'movies', // [Optional] The relation on which to save the items
+                'inherit_context' => false, // [Optional] Set "false" to disable the context inheritance (true by default)
+                'order_field' => 'my_order_field', // [Optional] The form field from which the order is obtained
+                'order_property' => 'show_order', // [Optional] The property on the model in which to save the order
+                'before_save' => true, // [Optional] Set "true" to use the renderer's native save mechanism (false by default)
             ),
             'template' => '{field}',
             'before_save' => function($item, $data) {

--- a/static/js/autocomplete/init.js
+++ b/static/js/autocomplete/init.js
@@ -54,12 +54,12 @@ define(
                 $hidden_input.val(infos.value);
             };
 
-// Delete selection (multiple only)
+            // Delete selection (multiple only)
             $content.on('click', 'span.delete-label', function() {
                 $nos(this).closest('.label-result-autocomplete').remove();
             });
 
-// Initialize the autocomplete
+            // Initialize the autocomplete
             autocomplete($content, {
                 on_click : function(infos) {
                     var $input = infos.root;

--- a/static/js/modelsearch.js
+++ b/static/js/modelsearch.js
@@ -1,6 +1,12 @@
 // Update the post attribute on model selection
 require(['jquery-nos'], function($nos) {
 
+    // Sets the default selected model
+    $nos('body').on('init_autocomplete.renderer', 'input.autocomplete', function() {
+        var $select = $nos(this).closest('.modelsearch').find('select');
+        update_autocomplete_post($select);
+    });
+
     // Update autocomplete on model change
     $nos('body').on('change', 'div.modelsearch select', function() {
         var $select = $nos(this);
@@ -14,13 +20,16 @@ require(['jquery-nos'], function($nos) {
             autoCompleteHidden = true;
         }
 
-        show = autoCompleteHidden ? $external : $autocomplete;
-        hide = autoCompleteHidden ? $autocomplete : $external;
-        hide.addClass('ms-hidden');
-        show.removeClass('ms-hidden');
-
+        if (autoCompleteHidden) {
+            $external.removeClass('ms-hidden');
+            $autocomplete.addClass('ms-hidden');
+        } else {
+            $autocomplete.removeClass('ms-hidden');
+            $external.addClass('ms-hidden');
+        }
 
         update_autocomplete_post($select);
+
         // Clear the search and value fields
         $select.closest('.modelsearch').find('[name="search[]"], .ms-value input[type="hidden"]').val('');
     });

--- a/views/hasmany/items.view.php
+++ b/views/hasmany/items.view.php
@@ -37,9 +37,15 @@
     $attr = array(
         'data-icon' => 'plus',
         'data-model' => $model,
+        'data-context' => $context,
         'data-relation' => $relation,
         'data-order' => !empty($options['order']) ? 1 : 0,
     );
+
+    if (\Arr::get($options, 'inherit_context', true)) {
+        $attr['data-context'] = $item->get_context();
+    }
+
     $attr = \Arr::merge($attr, $data);
     if (!isset($options['add']) || $options['add']) {
         ?>

--- a/views/modelsearch/inputs.php
+++ b/views/modelsearch/inputs.php
@@ -26,16 +26,16 @@ if (!count($available_models)) {
             <label><?= $label ?></label>
             <select name="<?= \Arr::get($options, 'names.model') ?>">
                 <?php
-                if ($options['external'] !== true) {
+                if ($options['external'] !== true && \Arr::get($options, 'allow_none', true)) {
                     ?>
                     <option value=""><?= __('None') ?></option>
-                <?php
+                    <?php
                 }
                 foreach ($available_models as $model => $label) {
-                        $selected = ($model == $current_model) ? 'selected="selected"' : '';
-                        if (empty($current_model) && $model == '') {
-                            $selected = 'selected="selected"';
-                        }
+                    $selected = ($model == $current_model) ? 'selected="selected"' : '';
+                    if (empty($current_model) && $model == '') {
+                        $selected = 'selected="selected"';
+                    }
                     ?>
                     <option value="<?= $model ?>" <?= $selected ?>><?= $label ?></option>
                 <?php } ?>


### PR DESCRIPTION
The bugfixes :
- **ModelSearch** + **Autocomplete** : The posted vars are no longer crypted (see #12) because they can be altered by external scripts (e.g the modelsearch dynamically sets the selected model in the post var). To send the sensitive data, I added a key called `data-autocomplete-config` that is automatically crypted when displaying the renderer and then decrypted in the autocompletion controller.
- **HasMany** : Context inheritance when creating a new item for the modelsearch to work as expected (hasmany)

The improvements :
- **ModelSearch** : New algorithm for handling the twinnable results (modelsearch) based on the algorithm of the `Orm_Behaviour_Twinnable::findContextOrMain()` method
- **ModelSearch** New option 'query_args' for customizing the query (modelsearch)

I also refactored some code and made some code style. These renderers are widely used and are relatively complex, it is important that it remains clean.
