### PR TITLE
Accurate count of items

### DIFF
--- a/views/hasmany/items.view.php
+++ b/views/hasmany/items.view.php
@@ -1,24 +1,25 @@
 <?php
 \Nos\I18n::current_dictionary('novius_renderers::default');
+$defaultItem = (bool)\Arr::get($options, 'default_item', true);
+$listItems = null;
+if (!empty($relation) && !empty($item)) {
+    $listItems = $item->{$relation};
+}
+elseif ($value) {
+    $listItems = array();
+    foreach ($value as $elem) {
+        $newModel = $model::forge();
+        foreach ($elem as $property => $elemValue) {
+            $newModel->$property = $elemValue;
+        }
+        $listItems[] = $newModel;
+    }
+}
 ?>
-<div class="hasmany_items count-items-js" data-nb-items="<?= empty($item->{$relation}) ? 1 : count($item->{$relation}) ?>">
+<div class="hasmany_items count-items-js" data-nb-items="<?= empty($listItems) ? (int)$defaultItem : count($listItems) ?>">
     <div class="item_list">
         <?php
         $i = 0;
-        $listItems = null;
-        if (!empty($relation) && !empty($item)) {
-            $listItems = $item->{$relation};
-        }
-        elseif ($value) {
-            $listItems = array();
-            foreach ($value as $elem) {
-                $newModel = $model::forge();
-                foreach ($elem as $property => $elemValue) {
-                    $newModel->$property = $elemValue;
-                }
-                $listItems[] = $newModel;
-            }
-        }
 
         if (!empty($listItems)) {
             foreach ($listItems as $o) {
@@ -26,7 +27,7 @@
                 echo \Novius\Renderers\Renderer_HasMany::render_fieldset($o, $relation, $i, $options, $data);
                 $i++;
             }
-        } elseif (\Arr::get($options, 'default_item', true)) {
+        } elseif ($defaultItem) {
             // Display an empty item in case none have already been added
             echo \Novius\Renderers\Renderer_HasMany::render_fieldset($model::forge(), $relation, $i, $options, $data);
         }


### PR DESCRIPTION
There is a small bug that put an incorrect value in the data-nb-items attribute if we have no relation but multiple items. (for example in an enhancer popup).

This bugfix takes the number of items selected into account. It also put the attribute at 0 if the default-item option is disabled.
