### PR TITLE
Check number of items not the relation

### DIFF
--- a/views/hasmany/items.view.php
+++ b/views/hasmany/items.view.php
@@ -1,24 +1,26 @@
 <?php
 \Nos\I18n::current_dictionary('novius_renderers::default');
+$listItems = null;
+if (!empty($relation) && !empty($item)) {
+    $listItems = $item->{$relation};
+}
+elseif ($value) {
+    $listItems = array();
+    foreach ($value as $elem) {
+        $newModel = $model::forge();
+        foreach ($elem as $property => $elemValue) {
+            $newModel->$property = $elemValue;
+        }
+        $listItems[] = $newModel;
+    }
+}
+
+$defaultItem =\Arr::get($options, 'default_item', true);
 ?>
-<div class="hasmany_items count-items-js" data-nb-items="<?= empty($item->{$relation}) ? 1 : count($item->{$relation}) ?>">
+<div class="hasmany_items count-items-js" data-nb-items="<?= empty($listItems) ? (int)$defaultItem : count($listItems) ?>">
     <div class="item_list">
         <?php
         $i = 0;
-        $listItems = null;
-        if (!empty($relation) && !empty($item)) {
-            $listItems = $item->{$relation};
-        }
-        elseif ($value) {
-            $listItems = array();
-            foreach ($value as $elem) {
-                $newModel = $model::forge();
-                foreach ($elem as $property => $elemValue) {
-                    $newModel->$property = $elemValue;
-                }
-                $listItems[] = $newModel;
-            }
-        }
 
         if (!empty($listItems)) {
             foreach ($listItems as $o) {
@@ -26,7 +28,7 @@
                 echo \Novius\Renderers\Renderer_HasMany::render_fieldset($o, $relation, $i, $options, $data);
                 $i++;
             }
-        } elseif (\Arr::get($options, 'default_item', true)) {
+        } elseif ($defaultItem) {
             // Display an empty item in case none have already been added
             echo \Novius\Renderers\Renderer_HasMany::render_fieldset($model::forge(), $relation, $i, $options, $data);
         }

--- a/views/hasmany/items.view.php
+++ b/views/hasmany/items.view.php
@@ -15,7 +15,7 @@ elseif ($value) {
     }
 }
 
-$defaultItem =\Arr::get($options, 'default_item', true);
+$defaultItem = \Arr::get($options, 'default_item', true);
 ?>
 <div class="hasmany_items count-items-js" data-nb-items="<?= empty($listItems) ? (int)$defaultItem : count($listItems) ?>">
     <div class="item_list">

--- a/views/hasmany/items.view.php
+++ b/views/hasmany/items.view.php
@@ -4,7 +4,7 @@ $listItems = null;
 if (!empty($relation) && !empty($item)) {
     $listItems = $item->{$relation};
 }
-elseif ($value) {
+elseif (!empty($value)) {
     $listItems = array();
     foreach ($value as $elem) {
         $newModel = $model::forge();

--- a/views/hasmany/items.view.php
+++ b/views/hasmany/items.view.php
@@ -3,8 +3,7 @@
 $listItems = null;
 if (!empty($relation) && !empty($item)) {
     $listItems = $item->{$relation};
-}
-elseif (!empty($value)) {
+} elseif (!empty($value)) {
     $listItems = array();
     foreach ($value as $elem) {
         $newModel = $model::forge();


### PR DESCRIPTION
There is a bug that wrongly set the number of items when the has many is populated by an array instead of a relationship.

This cause some issues determining the index of new elements.

Also i set by default this number of items at 0 if the default_item directive is set to false.
