### PR TITLE
Bugfix/has many pr

### DIFF
--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -62,7 +62,8 @@ class Renderer_HasMany extends \Nos\Renderer
         $name = $this->name;
 
         $values = \Arr::get($data, $name);
-        if(empty($values) || $values === $item->$name) {
+        $postData = \Input::post($name);
+        if(empty($values) && empty($postData)) {
             $item->$name = array();
             // When the input array is empty (which happens when the user tries to remove all childs),
             // the relation array (array(id => Model)) is given instead, which prevents us to remove the childs from database.

--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -63,13 +63,12 @@ class Renderer_HasMany extends \Nos\Renderer
 
         $values = \Arr::get($data, $name);
         $postData = \Input::post($name);
+        $item->$name = array();
         if(empty($values) && empty($postData)) {
-            $item->$name = array();
             // When the input array is empty (which happens when the user tries to remove all childs),
             // the relation array (array(id => Model)) is given instead, which prevents us to remove the childs from database.
             return true;
         }
-        $item->$name = array();
 
         $orderField = \Arr::get($this->renderer_options, 'order_field');
         $orderProperty = \Arr::get($this->renderer_options, 'order_property');

--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -60,12 +60,16 @@ class Renderer_HasMany extends \Nos\Renderer
             return true;
         }
         $name = $this->name;
-        $item->$name = array();
 
-        $values        = \Arr::get($data, $name);
-        if (empty($values)) {
+        $values = \Arr::get($data, $name);
+        if(empty($values) || $values === $item->$name) {
+            $item->$name = array();
+            // When the input array is empty (which happens when the user tries to remove all childs),
+            // the relation array (array(id => Model)) is given instead, which prevents us to remove the childs from database.
             return true;
         }
+        $item->$name = array();
+
         $orderField = \Arr::get($this->renderer_options, 'order_field');
         $orderProperty = \Arr::get($this->renderer_options, 'order_property');
         $model = $this->renderer_options['model'];

--- a/static/js/hasmany.js
+++ b/static/js/hasmany.js
@@ -17,7 +17,7 @@ require(['jquery-nos-wysiwyg'], function ($) {
     $(document).on('click', 'button.add-item-js', function(e) {
         var $button = $(this);
         var $container = $button.closest('.count-items-js');
-        var next = parseInt($container.data('nb-items'));
+        var next = $container.find('.hasmany_item').length;
         var btnData = $button.data();
         var data = {};
         for (i in btnData) {


### PR DESCRIPTION
See #31 

```
This fixes a bug preventing the user to remove all sub-elements (or just the last one if there is only one child) in Renderer_HasMany.
This was caused by an unexpected $data value, which contains $item->[hasManyProperty] when the given input is empty (which is the case when all sub-elements are removed).
```

There was a bug where the data won't be saved if the renderer has_many was inserted in another one. This way i check if the post variable is set before deleting everything.

I also changed a cosmetic value for the index of newly inserted element in the javascript.
