### PR TITLE
Fixed inconsistency with 'duplicate' => false

### DIFF
--- a/classes/controller/admin/hasmany.ctrl.php
+++ b/classes/controller/admin/hasmany.ctrl.php
@@ -12,6 +12,7 @@ class Controller_Admin_HasMany extends \Nos\Controller_Admin_Application
         $forge = \Input::get('forge', array());
         $context = \Input::get('context');
         $view = \Input::get('view');
+        $duplicate = \Input::get('duplicate', true);
 
         // Duplicates an item
         if (!empty($forge)) {
@@ -28,7 +29,11 @@ class Controller_Admin_HasMany extends \Nos\Controller_Admin_Application
         }
 
         // Renders the fieldset
-        $return = Renderer_HasMany::render_fieldset($item, $relation, $index, array('order' => (int)$order, 'content_view' => $view));
+        $return = Renderer_HasMany::render_fieldset($item, $relation, $index, array(
+            'order'        => (int) $order,
+            'content_view' => $view,
+            'duplicate'    => $duplicate,
+        ));
         \Response::forge($return)->send(true);
         exit();
     }

--- a/views/hasmany/items.view.php
+++ b/views/hasmany/items.view.php
@@ -42,6 +42,7 @@ $defaultItem = \Arr::get($options, 'default_item', true);
         'data-relation' => $relation,
         'data-view'    => \Arr::get($options, 'content_view'),
         'data-order' => !empty($options['order']) ? 1 : 0,
+        'data-duplicate' => !empty($options['duplicate']) ? 1 : 0,
     );
 
     if (\Arr::get($options, 'inherit_context', true)) {


### PR DESCRIPTION
This fixes an inconsistency in Renderer_HasMany. When `duplicate` was set to `false`, the button was still visible on new lines.
