### PR TITLE
Bugfix delete has many

### DIFF
--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -64,7 +64,8 @@ class Renderer_HasMany extends \Nos\Renderer
         $values = \Arr::get($data, $name);
         $postData = \Input::post($name);
         $item->$name = array();
-        if(!empty($values) && empty($postData)) {
+        $isPopulatedWithItem = !empty($values) && is_object(current($values));
+        if(empty($values) || ($isPopulatedWithItem && empty($postData))) {
             // When the input array is empty (which happens when the user tries to remove all childs),
             // the relation array (array(id => Model)) is given instead, which prevents us to remove the childs from database.
             return true;

--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -64,7 +64,7 @@ class Renderer_HasMany extends \Nos\Renderer
         $values = \Arr::get($data, $name);
         $postData = \Input::post($name);
         $item->$name = array();
-        if(empty($values) && empty($postData)) {
+        if(!empty($values) && empty($postData)) {
             // When the input array is empty (which happens when the user tries to remove all childs),
             // the relation array (array(id => Model)) is given instead, which prevents us to remove the childs from database.
             return true;


### PR DESCRIPTION
There was a bug making impossible to delete all items when using the before_save option. The thing is that there is always something in values if every element is deleted. But sometime there also is nothing in the $_POST array since a Renderer_HasMany can be inserted inside an other and thus lose its "real" name.

Now if we have something made of objects in values and no input post or simply no values, we consider the renderer to be empty.
