### PR TITLE
Hasmany - Implements twinnable relation in the before_save

### DIFF
--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -52,107 +52,17 @@ class Renderer_HasMany extends \Nos\Renderer
         return $this->template($return);
     }
 
-    public function before_save($item, $data)
-    {
-        parent::before_save($item, $data);
-        // This part of the code is disabled if the before_save renderer_option is not defined.
-        if (!\Arr::get($this->renderer_options, 'before_save')) {
-            return true;
-        }
-        $name = $this->name;
-
-        $values = \Arr::get($data, $name);
-        $postData = \Input::post($name);
-        $item->$name = array();
-        $isPopulatedWithItem = !empty($values) && is_object(current($values));
-        if(empty($values) || ($isPopulatedWithItem && empty($postData))) {
-            // When the input array is empty (which happens when the user tries to remove all childs),
-            // the relation array (array(id => Model)) is given instead, which prevents us to remove the childs from database.
-            return true;
-        }
-
-        $orderField = \Arr::get($this->renderer_options, 'order_field');
-        $orderProperty = \Arr::get($this->renderer_options, 'order_property');
-        $model = $this->renderer_options['model'];
-        $pk = current($model::primary_key());
-        if (empty($pk)) {
-            return true;
-        }
-
-        foreach ($values as $v) {
-            $empty = true;
-            // If the item already exists, the primary key is given so we can find it, otherwise we create a new one
-            if (!empty($v[$pk])) {
-                $subItem = $model::find($v[$pk]);
-            } else {
-                $subItem = $model::forge();
-            }
-            unset($v[$pk]);
-
-            // Set the correct value for the order property
-            if ($orderField) {
-                $subItem->$orderProperty = $v[$orderField];
-                unset($v[$orderField]);
-            }
-
-            // Fill the model with every value given in POST
-            foreach ($v as $property => $value) {
-                if (!empty($value)) {
-                    $empty = false;
-                }
-                $subItem->$property = $value;
-            }
-            // Only add a filled item to the model, this avoid saving an empty item if the default_item option is true
-            if (!$empty) {
-                // Trigger the before save of all the fields of the has_many
-                $config = static::getConfig($subItem, array());
-                $fieldset = static::getFieldSet($config, $subItem);
-                foreach ($fieldset->field() as $field) {
-                    $field->before_save($subItem, $v);
-                    $callback = \Arr::get($config, 'fieldset_fields.' . $field->name . '.before_save');
-                    if (!empty($callback) && is_callable($callback)) {
-                        $callback($subItem, $v);
-                    }
-                }
-                if (!empty($subItem->$pk)) {
-                    $item->{$name}[$subItem->$pk] = $subItem;
-                } else {
-                    $item->{$name}[] = $subItem;
-                }
-            }
-        }
-        return true;
-    }
-
     /**
-     * Return the fieldset from the config, populated by the item
-     * @param $config
-     * @param $item
+     * Renders the fieldset
      *
-     * @return \Fieldset
-     */
-    protected static function getFieldSet($config, $item)
-    {
-        $fieldset = \Fieldset::build_from_config($config['fieldset_fields'], $item, array('save' => false, 'auto_id' => false));
-        $fieldset->populate_with_instance($item);
-        return $fieldset;
-    }
-
-    /**
-     * Get the configuration of the form, triggering the novius_renderers.fieldset_config event
      * @param $item
-     * @param $data
-     *
-     * @return array
+     * @param $relation
+     * @param null $index
+     * @param array $renderer_options
+     * @param array $data
+     * @return string
+     * @throws \FuelException
      */
-    protected static function getConfig($item, $data) {
-        $class       = get_class($item);
-        $config_file = \Config::configFile($class);
-        $config      = \Config::load(implode('::', $config_file), true);
-        \Event::trigger_function('novius_renderers.fieldset_config', array('config' => &$config, 'item' => $item, 'data' => $data));
-        return $config;
-    }
-
     public static function render_fieldset($item, $relation, $index = null, $renderer_options = array(), $data = array())
     {
         $renderer_options = \Arr::merge(static::$DEFAULT_RENDERER_OPTIONS, $renderer_options);
@@ -170,7 +80,6 @@ class Renderer_HasMany extends \Nos\Renderer
                 $fields[] = $field;
             }
         }
-
 
         $fieldset->form()->set_config('field_template', '<tr><th>{label}</th><td>{field}</td></tr>');
         $view_params = array(
@@ -202,28 +111,263 @@ class Renderer_HasMany extends \Nos\Renderer
         return strtr($return, $replaces);
     }
 
+    /**
+     * Automatically saves the related item
+     *
+     * @param $item
+     * @param $data
+     * @return bool
+     */
+    public function before_save($item, $data)
+    {
+        parent::before_save($item, $data);
+
+        // Checks if auto save is enabled
+        if (\Arr::get($this->renderer_options, 'dont_save', !\Arr::get($this->renderer_options, 'before_save'))) {
+            return true;
+        }
+
+        // Gets the relation properties
+        $model = $this->renderer_options['model'];
+        $modelPks = $model::primary_key();
+        $modelPk = current($model::primary_key());
+        $modelContextField = $this->getItemContextField($model);
+        $modelContextCommonField= $this->getItemContextCommonField($model);
+        $modelContextMainField = $this->getItemContextMainField($model);
+        $relationName = $this->name;
+        $relation = $item->relations($relationName);
+
+        // Gets the new relation data
+        $values = \Arr::get($data, $relationName);
+        $postData = \Input::post($relationName);
+
+        $isPopulatedWithItem = !empty($values) && is_object(current($values));
+        $isRelationTwinnable = is_a($relation, 'Nos\\Orm_Twinnable_HasMany');
+
+        // Sort/order properties
+        $orderProperty = \Arr::get($this->renderer_options, 'order_property');
+        $orderField = \Arr::get($this->renderer_options, 'order_field', $orderProperty);
+
+        // Gets the item context
+        $itemContext = $isRelationTwinnable ? \Input::post($this->getItemContextField($item), $this->getItemContext($item)) : null;
+
+        // Initializes the related items
+        if ($isRelationTwinnable && !empty($item->{$relationName})) {
+            // Removes the related items in the current context
+            $item->{$relationName} = array_filter($item->{$relationName}, function($relatedItem) use ($modelContextField, $itemContext) {
+                return $relatedItem->{$modelContextField} != $itemContext;
+            });
+        } else {
+            // Resets the related items
+            $item->{$relationName} = array();
+        }
+
+        if (empty($modelPks) || empty($values) || ($isPopulatedWithItem && empty($postData))) {
+            // When the input array is empty (which happens when the user tries to remove all childs),
+            // the relation array (array(id => Model)) is given instead, which prevents us to remove the childs from database.
+            return true;
+        }
+
+        // The fields that will not be set on the related items
+        $ignored_fields = \Arr::merge($modelPks, array(
+            $modelContextCommonField,
+            $modelContextMainField,
+            $orderField
+        ));
+
+        // Creates/updates the related items
+        foreach ($values as $v) {
+
+            // Searches the related item
+            $relatedItem = null;
+            $relatedItemId = \Arr::get($v, $modelPk);
+            if (!empty($relatedItemId)) {
+
+                // Queries the database
+                $relatedItem = $model::query()
+                    ->where($modelPk, '=', $relatedItemId)
+                    ->get_one();
+
+                // If the context of the related item differs from the context of the item then creates a new one
+                if (!empty($relatedItem) && $isRelationTwinnable && $relatedItem->{$modelContextField} != $itemContext) {
+                    $relatedItemCommonId = $relatedItem->{$modelContextCommonField};
+                    // Forges a new related item
+                    $relatedItem = $model::forge();
+                    // Sets the common id from the original related item
+                    $relatedItem->{$modelContextCommonField} = $relatedItemCommonId;
+                }
+            }
+
+            // Creates a new one if no related item found
+            if (empty($relatedItem)) {
+                $relatedItem = $model::forge();
+            }
+
+            // If twinnable then set the context from the item
+            if ($isRelationTwinnable) {
+                $relatedItem->{$modelContextField} = $itemContext;
+            }
+
+            // Sets the correct value for the order property
+            if (!empty($orderField)) {
+                $relatedItem->{$orderProperty} = \Arr::get($v, $orderField);
+                unset($v[$orderField]);
+            }
+
+            // Sets the properties values
+            $filled_values = 0;
+            $properties = $model::properties();
+            foreach ($v as $field => $value) {
+                // Checks if the property is valid and not ignored
+                if (!isset($properties[$field]) || in_array($field, $ignored_fields)) {
+                    continue;
+                }
+                $relatedItem->{$field} = $value;
+                if (!empty($value)) {
+                    $filled_values++;
+                }
+            }
+
+            // Skip this related item if no values were filled, to avoid saving an empty item
+            if (empty($filled_values)) {
+                continue;
+            }
+
+            // Trigger the before save of all the fields of the has_many
+            $config = static::getConfig($relatedItem, array());
+            $fieldset = static::getFieldSet($config, $relatedItem);
+            foreach ($fieldset->field() as $field) {
+                $field->before_save($relatedItem, $v);
+                $callback = \Arr::get($config, 'fieldset_fields.'.$field->name.'.before_save');
+                if (!empty($callback) && is_callable($callback)) {
+                    $callback($relatedItem, $v);
+                }
+            }
+
+            // Adds the related item
+            $item->{$relationName}[] = $relatedItem;
+        }
+
+        return false;
+    }
+
     public static function js_init()
     {
         return \View::forge('novius_renderers::hasmany/js', array(), false);
     }
 
-    public function getId() {
+    /**
+     * Gets the relation name
+     *
+     * @return mixed
+     */
+    public function getRelationName()
+    {
+        return \Arr::get($this->renderer_options, 'related', $this->name);
+    }
+
+    /**
+     * Return the fieldset from the config, populated by the item
+     * @param $config
+     * @param $item
+     *
+     * @return \Fieldset
+     */
+    protected static function getFieldSet($config, $item)
+    {
+        $fieldset = \Fieldset::build_from_config($config['fieldset_fields'], $item, array('save' => false, 'auto_id' => false));
+        $fieldset->populate_with_instance($item);
+        return $fieldset;
+    }
+
+    /**
+     * Get the configuration of the form, triggering the novius_renderers.fieldset_config event
+     * @param $item
+     * @param $data
+     *
+     * @return array
+     */
+    protected static function getConfig($item, $data)
+    {
+        $class       = get_class($item);
+        $config_file = \Config::configFile($class);
+        $config      = \Config::load(implode('::', $config_file), true);
+        \Event::trigger_function('novius_renderers.fieldset_config', array('config' => &$config, 'item' => $item, 'data' => $data));
+        return $config;
+    }
+
+    /**
+     * Gets or generates the renderer unique id
+     *
+     * @return array|mixed|string
+     */
+    public function getId()
+    {
         $id = $this->get_attribute('id');
         return !empty($id) ? $id : uniqid('hasmany_');
     }
 
     /**
-     * Returns the context of $item
+     * Returns the context of the specified $item
      *
      * @param $item
      * @return bool
      */
-    public function getItemContext($item) {
-        if (!empty($item)) {
-            if ($item::behaviours('Nos\Orm_Behaviour_Contextable') || $item::behaviours('Nos\Orm_Behaviour_Twinnable')) {
-                return $item->get_context();
-            }
+    public function getItemContext($item)
+    {
+        if (empty($item)) {
+            return false;
         }
-        return false;
+        if (!$item::behaviours('Nos\Orm_Behaviour_Contextable') && !$item::behaviours('Nos\Orm_Behaviour_Twinnable')) {
+            return false;
+        }
+        return $item->get_context();
+    }
+
+    /**
+     * Returns the field name of the context for the specified $model
+     *
+     * @param $model
+     * @return bool
+     */
+    public function getItemContextField($model)
+    {
+        $field = \Arr::get($this->getItemContextProperties($model), 'context_property');
+        return is_array($field) ? current($field) : $field;
+    }
+
+    /**
+     * Returns the field name of the context common id for the specified $model
+     *
+     * @param $model
+     * @return bool
+     */
+    public function getItemContextCommonField($model)
+    {
+        $field = \Arr::get($this->getItemContextProperties($model), 'common_id_property');
+        return is_array($field) ? current($field) : $field;
+    }
+
+    /**
+     * Returns the field name of the context common id for the specified $model
+     *
+     * @param $model
+     * @return bool
+     */
+    public function getItemContextMainField($model)
+    {
+        $field = \Arr::get($this->getItemContextProperties($model), 'is_main_property');
+        return is_array($field) ? current($field) : $field;
+    }
+
+    /**
+     * Returns the context properties of the specified $model
+     *
+     * @param $model
+     * @return array
+     */
+    public function getItemContextProperties($model)
+    {
+        return (array) $model::behaviours('Nos\Orm_Behaviour_Twinnable') ?: array();
     }
 }

--- a/novius_docs/hasmany/config_crud.sample
+++ b/novius_docs/hasmany/config_crud.sample
@@ -26,24 +26,11 @@ return array(
                 'model' => 'Model_MovieShow',
                 'related' => 'movies', // [Optional] The relation on which to save the items
                 'inherit_context' => false, // [Optional] Set "false" to disable the context inheritance (true by default)
-                'order_field' => 'my_order_field', // [Optional] The form field from which the order is obtained
                 'order_property' => 'show_order', // [Optional] The property on the model in which to save the order
+                'order_field' => 'my_order_field', // [Optional] The form field from which the order is obtained (default is order_property)
                 'before_save' => true, // [Optional] Set "true" to use the renderer's native save mechanism (false by default)
             ),
             'template' => '{field}',
-            'before_save' => function($item, $data) {
-                $values = $data['shows'];
-                $item->shows = array();
-                foreach ($values as $v) {
-                    if (!empty($v['show_id'])) {
-                        $r = Model_MovieShow::find($v['show_id']);
-                        $item->shows[$v['show_id']] = $r;
-                    } else {
-                        $r = Model_MovieShow::forge();
-                        $item->shows[] = $r;
-                    }
-                }
-            }
         ),
     )
 );

--- a/views/hasmany/items.view.php
+++ b/views/hasmany/items.view.php
@@ -1,5 +1,7 @@
 <?php
 \Nos\I18n::current_dictionary('novius_renderers::default');
+
+// Gets the related items
 $listItems = null;
 if (!empty($relation) && !empty($item)) {
     $listItems = $item->{$relation};
@@ -14,13 +16,20 @@ if (!empty($relation) && !empty($item)) {
     }
 }
 
+// Sorts the related items if there is an order property
+$orderProperty = \Arr::get($options, 'order_property');
+if (!empty($orderProperty)) {
+    uasort($listItems, function ($a, $b) use ($orderProperty) {
+        return intval($a->{$orderProperty}) - intval($b->{$orderProperty});
+    });
+}
+
 $defaultItem = \Arr::get($options, 'default_item', true);
 ?>
 <div class="hasmany_items count-items-js" data-nb-items="<?= empty($listItems) ? (int)$defaultItem : count($listItems) ?>">
     <div class="item_list">
         <?php
         $i = 0;
-
         if (!empty($listItems)) {
             foreach ($listItems as $o) {
                 // Build fieldset and return view


### PR DESCRIPTION
The HasMany renderer now **automatically** handles **twinnable relation** by checking the relation type.

Items are handled **symmetrically** between each context, if you create one in a context, it will appear in the other contexts, if you delete one from a context, it will be deleted from the other contexts.

**Common fields** are handled (if you change in one context it will change in all contexts) but without the native mechanism that disable the direct edition of the field (PR if you need it).

For the **order feature** to work properly you need to add the order field in the common fields of the twinnable behaviour, otherwise strange things may happen...

To display the related items in a specific context, please consider using the findContextOrMain() method.

Note: _to avoid confusion with the "before_save" callback of the field, I added a new renderer option called "dont_save" which acts like the inverse of "before_save", for now you can set one or the other, it doesn't matter, but in a future major release we will deprecate the "before_save" in favor of the "dont_save" option (which will be default set to true)._
