### PR TITLE
Patch when all hasmany has been deleted

### DIFF
--- a/classes/renderer/hasmany.php
+++ b/classes/renderer/hasmany.php
@@ -165,7 +165,7 @@ class Renderer_HasMany extends \Nos\Renderer
         if (empty($modelPks) || empty($values) || ($isPopulatedWithItem && empty($postData))) {
             // When the input array is empty (which happens when the user tries to remove all childs),
             // the relation array (array(id => Model)) is given instead, which prevents us to remove the childs from database.
-            return true;
+            return false;
         }
 
         // The fields that will not be set on the related items


### PR DESCRIPTION
[RENDERER HAS_MANY] A minor fix to prevent no deleting all items in relation, when no _before_save_ was present in crud and dont_save is false.

The false return prevent execution of default before_save in Fieldset::defaultComplete() method.
