### PR TITLE
Prevent error when method not exist on one model

### DIFF
--- a/classes/controller/admin/modelsearch.php
+++ b/classes/controller/admin/modelsearch.php
@@ -168,7 +168,9 @@ class Controller_Admin_ModelSearch extends Controller_Admin_Autocomplete
                         $label = '';
                         if (array_key_exists($result['value'], $items)) {
                             $item  = $items[$result['value']];
-                            $label = $item->$display_method();
+                            if (method_exists($item, $display_method)) {
+                                $label = $item->$display_method();
+                            }
                         }
                         if (!empty($label)) {
                             $results[$resultKey]['label'] = $label;


### PR DESCRIPTION
Allow to use a custom method on modelsearch which not used on all model