### PR TITLE
Created a new "appdesk picker" renderer

### DIFF
--- a/classes/controller/admin/appdeskpicker.ctrl.php
+++ b/classes/controller/admin/appdeskpicker.ctrl.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Novius\Renderers;
+
+class Controller_Admin_AppdeskPicker extends \Nos\Controller_Admin_Application
+{
+    public function action_main($edit = false)
+    {
+        $models = json_decode(\Crypt::decode((string) \Input::get('models')), true);
+        if (empty($models)) {
+            return null;
+        }
+
+        return \View::forge('novius_renderers::appdeskpicker/main', array(
+            'models' => $models,
+        ), false);
+    }
+}

--- a/classes/renderer/appdeskpicker.php
+++ b/classes/renderer/appdeskpicker.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Novius\Renderers;
+
+class Renderer_AppdeskPicker extends \Fieldset_Field
+{
+    protected $renderer_options = array();
+
+    public function build()
+    {
+        $item = $this->fieldset->getInstance();
+        $options = \Arr::get($this->attributes, 'renderer_options', []);
+
+        $selectedItem = null;
+        $selectedTypeConfig = null;
+        if (!empty($item->{$options['field_id']}) && !empty($item->{$options['field_class']})) {
+            $id = $item->{$options['field_id']};
+            $class = $item->{$options['field_class']};
+            $selectedItem = $class::find($id);
+
+            foreach ($options['models'] as $type) {
+                if ($type['model'] == $item->{$options['field_class']}) {
+                    $selectedTypeConfig = $type;
+                    break;
+                }
+            }
+        }
+
+        $renderer = (string) \View::forge('novius_renderers::appdeskpicker/renderer', array(
+            'options' => $options,
+            'item' => $item,
+            'name' => $this->name,
+            'selectedItem' => $selectedItem,
+            'selectedTypeConfig' => $selectedTypeConfig,
+        ), false);
+
+        return $this->template($renderer);
+    }
+
+    public function before_save($item, $data)
+    {
+        $options = \Arr::get($this->attributes, 'renderer_options', []);
+        $item->{$options['field_id']} = \Arr::get($data, $this->name.'.id');
+        $item->{$options['field_class']} = \Arr::get($data, $this->name.'.class');
+    }
+}

--- a/lang/fr/appdeskpicker.lang.php
+++ b/lang/fr/appdeskpicker.lang.php
@@ -1,0 +1,14 @@
+<?php
+
+return array(
+    #: views/appdeskpicker/renderer.view.php:13
+    #: views/appdeskpicker/renderer.view.php:58
+    'Nothing selected yet' => 'Aucun élément sélectionné',
+
+    #: views/appdeskpicker/renderer.view.php:20
+    'Deselect' => 'Désélectionner',
+
+    #: views/appdeskpicker/renderer.view.php:25
+    #: views/appdeskpicker/renderer.view.php:39
+    'Select an item' => 'Sélectionner un élément',
+);

--- a/lang/fr/appdeskpicker.po
+++ b/lang/fr/appdeskpicker.po
@@ -1,0 +1,13 @@
+#: views/appdeskpicker/renderer.view.php:13
+#: views/appdeskpicker/renderer.view.php:58
+msgid "Nothing selected yet"
+msgstr "Aucun élément sélectionné"
+
+#: views/appdeskpicker/renderer.view.php:20
+msgid "Deselect"
+msgstr "Désélectionner"
+
+#: views/appdeskpicker/renderer.view.php:25
+#: views/appdeskpicker/renderer.view.php:39
+msgid "Select an item"
+msgstr "Sélectionner un élément"

--- a/novius_docs/appdeskpicker/readme.md
+++ b/novius_docs/appdeskpicker/readme.md
@@ -1,0 +1,39 @@
+# Introduction
+
+This renderer allows the user to choose between multiple model types, and then a specific item.
+The existing appdesks are reused (thus allowing to search, filter and paginate properly through the existing items).
+
+# Configuration sample (crud field configuration)
+
+```php
+    'foo_link' => array( // This name doesn't really matter, only the configured keys below
+        'label' => __('Choose an item'),
+        'renderer' => \Novius\Renderers\Renderer_AppdeskPicker::class,
+        'renderer_options' => [
+            'field_id' => 'foo_link_id',
+            'field_class' => 'foo_link_class',
+            'models' => [
+                [
+                    'model' => \Nos\Media\Model_Media::class,
+                    'appdesk' => 'admin/noviusos_media/appdesk/index/appdesk_pick',
+                    'label' => __('Media'),
+                ],
+                [
+                    'model' => \Nos\Slideshow\Model_Slideshow::class,
+                    'appdesk' => 'admin/noviusos_slideshow/appdesk/index/appdesk_pick',
+                    'label' => __('Slideshow'),
+                ],
+                [
+                    'model' => \Nos\OnlineMediaFiles\Model_Media::class,
+                    'appdesk' => 'admin/novius_onlinemediafiles/appdesk/index/appdesk_pick',
+                    'label' => __('Online media'),
+                ],
+                [
+                    'model' => \Nos\Page\Model_Page::class,
+                    'appdesk' => 'admin/noviusos_page/appdesk/index/appdesk_pick',
+                    'label' => __('Page'),
+                ],
+            ],
+        ],
+    ),
+```

--- a/views/appdeskpicker/main.view.php
+++ b/views/appdeskpicker/main.view.php
@@ -1,0 +1,76 @@
+<?php
+    $uniqid = uniqid('tabs_');
+?>
+<style type="text/css">
+    #<?= $uniqid ?> {
+        box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        height: 100%;
+    }
+    #<?= $uniqid ?> > ul {
+        width: 18%;
+    }
+    #<?= $uniqid ?> > div {
+        width: 81%;
+        height: 100%;
+        position: relative;
+    }
+</style>
+<div id="<?= $uniqid ?>">
+    <ul>
+        <?php foreach ($models as $index => $model): ?>
+            <li>
+                <a
+                    href="#<?= $uniqid ?>-select-type-<?= $index ?>"
+                    data-appdesk-url="<?= e(\Arr::get($model, 'appdesk')) ?>"
+                    data-appdesk-model="<?= e(\Arr::get($model, 'model')) ?>"
+                >
+                    <?= \Arr::get($model, 'label', \Arr::get($model, 'model')) ?>
+                </a>
+            </li>
+        <?php endforeach ?>
+    </ul>
+    <?php foreach ($models as $index => $model): ?>
+        <div id="<?= $uniqid ?>-select-type-<?= $index ?>">
+        </div>
+    <?php endforeach ?>
+</div>
+<script type="text/javascript">
+    require([
+        'jquery-nos',
+        'wijmo.wijtabs',
+    ], function($) {
+        var loadAppdesk = function ($wijtab, target) {
+            var $tab = $(target.tab);
+            if (!$tab.data('loaded')) {
+                $(target.panel).load($tab.data('appdesk-url'));
+
+                $(target.panel).closest('.ui-dialog-content')
+                    .bind('appdesk_pick_' + $tab.data('appdesk-model'), function(e, item) {
+                        // On item selected, transmit the picked item to the renderer js through an event
+                        $(target.panel).closest('.ui-dialog-content').trigger('appdeskpicker-item-picked', item);
+                    });
+
+                $tab.data('loaded', true);
+            }
+        };
+
+        $(function() {
+            var $container = $('#<?= $uniqid ?>');
+
+            // Initializing wijtabs
+            $container.wijtabs({
+                alignment: 'left',
+                select: loadAppdesk,
+            }).end().nosFormUI();
+
+            // Loading first appdesk
+            loadAppdesk(null, {
+                tab: $('a[href="#<?= $uniqid ?>-select-type-0"]'),
+                panel: $('#<?= $uniqid ?>-select-type-0'),
+            });
+        });
+    });
+</script>
+

--- a/views/appdeskpicker/renderer.view.php
+++ b/views/appdeskpicker/renderer.view.php
@@ -1,0 +1,65 @@
+<?php
+    \Nos\I18n::current_dictionary(array('novius_renderers::appdeskpicker'));
+    $id = uniqid('appdeskpicker_');
+?>
+
+<div id="<?= $id ?>">
+    <?= \Form::hidden($name.'[id]', $item->{$options['field_id']}, array('class' => 'field-id')) ?>
+    <?= \Form::hidden($name.'[class]', $item->{$options['field_class']}, array('class' => 'field-class')) ?>
+    <div>
+        <span class="field-title"><?php
+            if (!empty($selectedItem)) {
+                echo $selectedTypeConfig['label'].' &gt; '.$selectedItem->title_item();
+            } else {
+                echo __('Nothing selected yet');
+            }
+        ?></span>
+        <button
+            type="button"
+            class="deselect-item"
+            style="margin-left: 1rem; <?= empty($selectedItem) ? 'display: none;' : '' ?>"
+        ><?= __('Deselect') ?></button>
+    </div>
+    <button
+        type="button"
+        class="select-item"
+    ><?= __('Select an item') ?></button>
+</div>
+
+<script type="text/javascript">
+    require([
+        'jquery-nos'
+    ], function ($) {
+        $(function () {
+            var models = <?= json_encode($options['models']) ?>;
+            var $container = $('#<?= $id ?>');
+
+            $container.find('.select-item').click(function() {
+                var $dialog = $container.nosDialog({
+                    contentUrl: 'admin/novius_renderers/appdeskpicker/main?models=<?= urlencode(\Crypt::encode(json_encode($options['models']))) ?>',
+                    title: <?= json_encode(__('Select an item')) ?>,
+                    ajax: true,
+                });
+
+                $dialog.on('appdeskpicker-item-picked', function (event, item) {
+                    var type = models.find(function (type) {
+                        return type.model == item._model;
+                    });
+                    $container.find('.field-id').val(item._id);
+                    $container.find('.field-class').val(item._model);
+                    $container.find('.field-title').text(type.label + ' > ' + item._title);
+                    $container.find('.deselect-item').show();
+                    $dialog.nosDialog('close');
+                });
+            });
+
+            $container.find('.deselect-item').click(function() {
+                $container.find('.field-id').val(null);
+                $container.find('.field-class').val(null);
+                $container.find('.field-title').text(<?= json_encode(__('Nothing selected yet')) ?>);
+                $container.find('.deselect-item').hide();
+            });
+        });
+    });
+</script>
+


### PR DESCRIPTION
This renderer allows the user to select an item through many types.

It reuses the existing appdesks, with all it's advantages (pagination, search, filters...).

![appdeskpicker_1](https://cloud.githubusercontent.com/assets/2553075/26689730/f832a2fc-46f6-11e7-94d5-95ec3879869e.png)

![appdeskpicker_2](https://cloud.githubusercontent.com/assets/2553075/26689768/1624a274-46f7-11e7-98bd-d6a0a5f1dd5b.png)

Configuration sample: 


```php
    'foo_link' => array( // This name doesn't really matter, only the configured keys below
        'label' => __('Choose an item'),
        'renderer' => \Novius\Renderers\Renderer_AppdeskPicker::class,
        'renderer_options' => [
            'field_id' => 'foo_link_id',
            'field_class' => 'foo_link_class',
            'models' => [
                [
                    'model' => \Nos\Media\Model_Media::class,
                    'appdesk' => 'admin/noviusos_media/appdesk/index/appdesk_pick',
                    'label' => __('Media'),
                ],
                [
                    'model' => \Nos\Slideshow\Model_Slideshow::class,
                    'appdesk' => 'admin/noviusos_slideshow/appdesk/index/appdesk_pick',
                    'label' => __('Slideshow'),
                ],
                [
                    'model' => \Nos\OnlineMediaFiles\Model_Media::class,
                    'appdesk' => 'admin/novius_onlinemediafiles/appdesk/index/appdesk_pick',
                    'label' => __('Online media'),
                ],
                [
                    'model' => \Nos\Page\Model_Page::class,
                    'appdesk' => 'admin/noviusos_page/appdesk/index/appdesk_pick',
                    'label' => __('Page'),
                ],
            ],
        ],
    ),
```
