### PR TITLE
Allow Renderer_MultiMedias to use template string

### DIFF
--- a/classes/renderer/multimedias.php
+++ b/classes/renderer/multimedias.php
@@ -26,7 +26,7 @@ class Renderer_MultiMedias extends Renderer
             $this->set_value($this->getValueFromInstance($item));
         }
 
-        $template = $this->template ?: $this->fieldset()->form()->get_config('field_template', "<tr><th>{label} :</th> <td>{field}</td></tr>");
+        $template = $this->template ?: $this->fieldset()->form()->get_config('field_template', "{field} {required}");
         
         $field = (string) \View::forge('novius_renderers::multimedias/inputs', array(
             'id'      => $id,

--- a/classes/renderer/multimedias.php
+++ b/classes/renderer/multimedias.php
@@ -26,13 +26,17 @@ class Renderer_MultiMedias extends Renderer
             $this->set_value($this->getValueFromInstance($item));
         }
 
-        return (string) \View::forge('novius_renderers::multimedias/inputs', array(
+        $template = $this->template ?: $this->fieldset()->form()->get_config('field_template', "<tr><th>{label} :</th> <td>{field}</td></tr>");
+        
+        $field = (string) \View::forge('novius_renderers::multimedias/inputs', array(
             'id'      => $id,
             'key'     => $this->getInputName(),
             'options' => $this->renderer_options,
             'item'    => $item,
             'value'   => $this->value,
         ), false);
+        
+        return str_replace(array('{label}', '{field}'), array($this->label, $field), $template);
     }
 
     /**


### PR DESCRIPTION
In a crud where this renderer coexists with other fields, its appearance seems "buggy" due to the fact that is does not display a label.
This PR allows the Render_Multimedias to:
- By default use the same template as the other fields (label + field)
- Use the `template` option (same as other fields) so we can only display the field without the label or whatever is needed

![renderer_multimedias - before](https://user-images.githubusercontent.com/8545893/29354619-7fb73c62-826e-11e7-8005-4442548b2812.png)
