### PR TITLE
Trying to properly handle the errors in the AppDeskPicker.

### DIFF
--- a/lang/fr/appdeskpicker.lang.php
+++ b/lang/fr/appdeskpicker.lang.php
@@ -11,4 +11,7 @@ return array(
     #: views/appdeskpicker/renderer.view.php:25
     #: views/appdeskpicker/renderer.view.php:39
     'Select an item' => 'Sélectionner un élément',
+
+    #: views/appdeskpicker/main.view.php:53
+    'You are not allowed to access to this application.' => 'Vous n\'êtes pas autorisé(e) à utiliser cette application.',
 );

--- a/lang/fr/appdeskpicker.po
+++ b/lang/fr/appdeskpicker.po
@@ -11,3 +11,7 @@ msgstr "Désélectionner"
 #: views/appdeskpicker/renderer.view.php:39
 msgid "Select an item"
 msgstr "Sélectionner un élément"
+
+#: views/appdeskpicker/main.view.php:53
+msgid "You are not allowed to access to this application."
+msgstr "Vous n'êtes pas autorisé(e) à utiliser cette application."

--- a/views/appdeskpicker/main.view.php
+++ b/views/appdeskpicker/main.view.php
@@ -1,4 +1,5 @@
 <?php
+    \Nos\I18n::current_dictionary(array('novius_renderers::appdeskpicker'));
     $uniqid = uniqid('tabs_');
 ?>
 <style type="text/css">
@@ -44,7 +45,18 @@
         var loadAppdesk = function ($wijtab, target) {
             var $tab = $(target.tab);
             if (!$tab.data('loaded')) {
-                $(target.panel).load($tab.data('appdesk-url'));
+                $(target.panel).load($tab.data('appdesk-url'), function (responseData) {
+                    try {
+                        var data = JSON.parse(responseData);
+                        if (data.hasOwnProperty('error')) {
+                            // An error happened, but it's glitchy and the error structure is inconsistent
+                            // across all appdesks, so we have to output a generic error message...
+                            $(target.panel).html(<?= json_encode(__('You are not allowed to access to this application.')) ?>);
+                        }
+                    } catch (e) {
+                        // It's not a valid JSON, so we have nothing to do
+                    }
+                });
 
                 $(target.panel).closest('.ui-dialog-content')
                     .bind('appdesk_pick_' + $tab.data('appdesk-model'), function(e, item) {


### PR DESCRIPTION
When the user doesn't have access to an appdesk, the plain JSON error was shown by the appdesk. For example, the user could see a message like:

> {"error":"We\u2019re afraid you\u2019ve not be given access to the Media Centre. Don\u2019t blame us though, we\u2019re not the ones who decide the permissions."}

Unfortunately, none of the appdesk that I tried returns a proper HTTP error code. It's always a 200 with a JSON containing an `error` property. And the content of this key is not always a string, sometimes it's a whole structure.

Because of this inconsistency, the only way to show a clean error message to the user was to intercept the ajax query triggered by the appdesk, through the "magic" callback of the `nosAppdesk.load` method. In a successful case, the HTML of the appdesk seems to be returned by this callback, while it's a JSON in case of an error, so I had to handle the case manually...