### PR TITLE
Adds the order field in the config sample for the HasMany renderer

### DIFF
--- a/novius_docs/hasmany/config_model.sample
+++ b/novius_docs/hasmany/config_model.sample
@@ -15,5 +15,12 @@ return array(
                 'datepicker' => array(),
             ),
         ),
+        // If you enable the sortable list feature (the "order" property on the renderer options), 
+        // you have to add the order field as a hidden field
+        //'show_order' => array(
+        //    'form' => array(
+        //        'type' => 'hidden',
+        //    )
+        //),
     )
 );


### PR DESCRIPTION
Without this field, the sortable list won't work.